### PR TITLE
Windows CI baseline: compile wbeamd-server cross-platform (issue #26)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,54 @@ build_apk_release:
     - if: $CI_COMMIT_TAG
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 
+build_windows_server:
+  stage: build
+  tags:
+    - windows
+    - zerotier
+    - build
+  before_script:
+    - |
+      $ErrorActionPreference = "Stop"
+      if ($env:CI_COMMIT_TAG) {
+        $tag = $env:CI_COMMIT_TAG
+        if ($tag.StartsWith("v") -or $tag.StartsWith("V")) {
+          $tag = $tag.Substring(1)
+        }
+        $env:WBEAM_VERSION = $tag
+      } else {
+        $env:WBEAM_VERSION = "0.0.0.$($env:CI_DEFAULT_BRANCH).$($env:CI_PIPELINE_IID).$($env:CI_COMMIT_SHORT_SHA)"
+      }
+      cmd /c "\"C:\BuildTools\Common7\Tools\VsDevCmd.bat\" -host_arch=x64 -arch=x64 && set" |
+        ForEach-Object {
+          if ($_ -match "^(.*?)=(.*)$") {
+            [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2], "Process")
+          }
+        }
+  script:
+    - |
+      Set-Location "$env:CI_PROJECT_DIR\host\rust"
+      cargo build --release -p wbeamd-server
+      New-Item -ItemType Directory -Path "$env:CI_PROJECT_DIR\dist" -Force | Out-Null
+      Copy-Item `
+        "$env:CI_PROJECT_DIR\host\rust\target\release\wbeamd-server.exe" `
+        "$env:CI_PROJECT_DIR\dist\wbeamd-server-$env:WBEAM_VERSION-windows-x86_64.exe" `
+        -Force
+      @(
+        "WBEAM_VERSION=$env:WBEAM_VERSION"
+        "CI_PIPELINE_ID=$env:CI_PIPELINE_ID"
+        "CI_COMMIT_SHA=$env:CI_COMMIT_SHA"
+        "CI_COMMIT_REF_NAME=$env:CI_COMMIT_REF_NAME"
+      ) | Set-Content -Path "$env:CI_PROJECT_DIR\dist\VERSION.txt" -Encoding ascii
+  artifacts:
+    paths:
+      - dist/*windows*.exe
+      - dist/VERSION.txt
+    expire_in: 14 days
+  rules:
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
 publish_github_release:
   stage: publish
   image: alpine:3.21

--- a/host/rust/crates/wbeamd-core/Cargo.toml
+++ b/host/rust/crates/wbeamd-core/Cargo.toml
@@ -6,10 +6,12 @@ license.workspace = true
 
 [dependencies]
 hostname.workspace = true
-nix.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 wbeamd-api = { path = "../wbeamd-api" }
+
+[target.'cfg(unix)'.dependencies]
+nix.workspace = true

--- a/host/rust/crates/wbeamd-core/src/infra/display_backends/mod.rs
+++ b/host/rust/crates/wbeamd-core/src/infra/display_backends/mod.rs
@@ -1,8 +1,41 @@
 use super::host_probe::{HostOs, HostProbe};
+#[cfg(unix)]
 use super::x11_monitor_object;
+#[cfg(unix)]
 use super::x11_real_output;
 
+#[cfg(unix)]
 mod linux;
+#[cfg(not(unix))]
+mod linux {
+    use super::{Activation, ActivationError, DisplayMode, HostProbe, VirtualMonitorProbe};
+
+    pub fn probe_virtual_monitor(host_probe: &HostProbe) -> VirtualMonitorProbe {
+        VirtualMonitorProbe {
+            supported: false,
+            resolver: "linux_backend_unavailable".to_string(),
+            missing_deps: vec!["unix-runtime".to_string()],
+            hint: format!(
+                "Linux virtual monitor backend is unavailable on this platform (os={})",
+                host_probe.os_name()
+            ),
+        }
+    }
+
+    pub fn activate(
+        _host_probe: &HostProbe,
+        mode: DisplayMode,
+        _serial_hint: &str,
+        _size: &str,
+    ) -> Result<Activation, ActivationError> {
+        if mode.is_virtual() {
+            return Err(ActivationError::Unsupported(
+                "Linux virtual monitor backend is unavailable on this platform".to_string(),
+            ));
+        }
+        Ok(Activation::default())
+    }
+}
 mod windows;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,7 +61,9 @@ impl DisplayMode {
 
 #[derive(Debug, Clone)]
 pub enum RuntimeHandle {
+    #[cfg(unix)]
     X11RealOutput(x11_real_output::X11RealOutputHandle),
+    #[cfg(unix)]
     X11MonitorObject(x11_monitor_object::X11MonitorObjectHandle),
 }
 
@@ -103,6 +138,7 @@ pub fn activate_start(
 }
 
 pub async fn stop_runtime(handle: RuntimeHandle) {
+    #[cfg(unix)]
     match handle {
         RuntimeHandle::X11RealOutput(h) => {
             let _ = x11_real_output::destroy(&h);
@@ -110,5 +146,9 @@ pub async fn stop_runtime(handle: RuntimeHandle) {
         RuntimeHandle::X11MonitorObject(h) => {
             let _ = x11_monitor_object::destroy(&h);
         }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = handle;
     }
 }

--- a/host/rust/crates/wbeamd-core/src/infra/host_probe.rs
+++ b/host/rust/crates/wbeamd-core/src/infra/host_probe.rs
@@ -7,8 +7,7 @@
 use std::env;
 use std::fs;
 use std::path::Path;
-
-use nix::libc;
+use std::process::Command;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostOs {
@@ -259,7 +258,9 @@ fn detect_session(os: HostOs) -> SessionKind {
 }
 
 fn has_wayland_socket() -> bool {
-    let uid = unsafe { libc::geteuid() };
+    let Some(uid) = current_uid() else {
+        return false;
+    };
     if uid == 0 {
         return false;
     }
@@ -277,6 +278,20 @@ fn has_wayland_socket() -> bool {
         }
     }
     false
+}
+
+fn current_uid() -> Option<u32> {
+    if let Some(uid) = env::var("UID").ok().and_then(|raw| raw.parse::<u32>().ok()) {
+        return Some(uid);
+    }
+    let out = Command::new("id").arg("-u").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse::<u32>()
+        .ok()
 }
 
 fn has_x11_socket() -> bool {

--- a/host/rust/crates/wbeamd-core/src/infra/mod.rs
+++ b/host/rust/crates/wbeamd-core/src/infra/mod.rs
@@ -5,7 +5,11 @@ pub mod host_probe;
 pub mod process;
 pub mod telemetry;
 pub mod virtual_display;
+#[cfg(unix)]
 pub mod x11_backend;
+#[cfg(unix)]
 pub mod x11_extend;
+#[cfg(unix)]
 pub mod x11_monitor_object;
+#[cfg(unix)]
 pub mod x11_real_output;

--- a/host/rust/crates/wbeamd-core/src/infra/process.rs
+++ b/host/rust/crates/wbeamd-core/src/infra/process.rs
@@ -5,10 +5,14 @@
 //! child to exit.
 
 use std::path::{Path, PathBuf};
+#[cfg(not(unix))]
+use std::process::Command as StdCommand;
 use std::process::Stdio;
 use std::time::Duration;
 
+#[cfg(unix)]
 use nix::sys::signal::{kill, Signal};
+#[cfg(unix)]
 use nix::unistd::Pid;
 use tokio::process::Command;
 use tokio::time::sleep;
@@ -24,6 +28,9 @@ pub fn build_streamer_command(
     cfg: &ActiveConfig,
     stream_port: u16,
 ) -> (Command, bool) {
+    #[cfg(windows)]
+    let rust_bin = root.join("host/rust/target/release/wbeamd-streamer.exe");
+    #[cfg(not(windows))]
     let rust_bin = root.join("host/rust/target/release/wbeamd-streamer");
     let use_rust = rust_bin.exists();
 
@@ -51,7 +58,13 @@ pub fn build_streamer_command(
         c
     } else {
         let script = root.join("host/scripts/stream_wayland_portal_h264.py");
-        let mut c = Command::new("python3");
+        let mut c = if cfg!(windows) {
+            let mut py = Command::new("py");
+            py.arg("-3");
+            py
+        } else {
+            Command::new("python3")
+        };
         c.arg("-u")
             .arg(script)
             .arg("--profile")
@@ -86,10 +99,24 @@ pub fn build_streamer_command(
 
 /// Send SIGTERM then SIGKILL to `pid` with a short delay in between.
 pub async fn terminate_pid(pid: u32) {
-    let p = Pid::from_raw(pid as i32);
-    let _ = kill(p, Signal::SIGTERM);
-    sleep(Duration::from_millis(300)).await;
-    let _ = kill(p, Signal::SIGKILL);
+    #[cfg(unix)]
+    {
+        let p = Pid::from_raw(pid as i32);
+        let _ = kill(p, Signal::SIGTERM);
+        sleep(Duration::from_millis(300)).await;
+        let _ = kill(p, Signal::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    {
+        let pid_s = pid.to_string();
+        let _ = StdCommand::new("taskkill")
+            .args(["/PID", &pid_s, "/T"])
+            .status();
+        sleep(Duration::from_millis(300)).await;
+        let _ = StdCommand::new("taskkill")
+            .args(["/PID", &pid_s, "/T", "/F"])
+            .status();
+    }
 }
 
 /// Parse a GStreamer/libx264 bitrate output line such as
@@ -160,6 +187,11 @@ pub fn build_revision() -> String {
 
 /// Resolve the path to the Rust streamer binary.
 pub fn rust_streamer_bin(root: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        return root.join("host/rust/target/release/wbeamd-streamer.exe");
+    }
+    #[cfg(not(windows))]
     root.join("host/rust/target/release/wbeamd-streamer")
 }
 

--- a/host/rust/crates/wbeamd-core/src/lib.rs
+++ b/host/rust/crates/wbeamd-core/src/lib.rs
@@ -1,12 +1,14 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+#[cfg(unix)]
 use nix::libc;
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -518,13 +520,24 @@ impl Inner {
 }
 
 pub struct InstanceLock {
-    file: File,
+    file: Option<File>,
+    #[cfg(windows)]
+    path: PathBuf,
 }
 
 impl Drop for InstanceLock {
     fn drop(&mut self) {
-        unsafe {
-            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        #[cfg(unix)]
+        if let Some(file) = self.file.as_ref() {
+            unsafe {
+                libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+            }
+        }
+        #[cfg(windows)]
+        {
+            // Close handle before cleanup, otherwise Windows keeps the file in-use.
+            self.file.take();
+            let _ = std::fs::remove_file(&self.path);
         }
     }
 }
@@ -569,24 +582,46 @@ impl DaemonCore {
     }
 
     pub fn acquire_lock(path: &Path) -> Result<InstanceLock, CoreError> {
-        let mut file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(path)
-            .map_err(|e| CoreError::Io(e.to_string()))?;
-
-        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
-        if rc != 0 {
-            return Err(CoreError::LockHeld(path.display().to_string()));
-        }
+        #[cfg(unix)]
+        let mut file = {
+            let file = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .open(path)
+                .map_err(|e| CoreError::Io(e.to_string()))?;
+            let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if rc != 0 {
+                return Err(CoreError::LockHeld(path.display().to_string()));
+            }
+            file
+        };
+        #[cfg(windows)]
+        let mut file = {
+            match OpenOptions::new()
+                .create_new(true)
+                .read(true)
+                .write(true)
+                .open(path)
+            {
+                Ok(file) => file,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    return Err(CoreError::LockHeld(path.display().to_string()));
+                }
+                Err(e) => return Err(CoreError::Io(e.to_string())),
+            }
+        };
 
         let pid = std::process::id();
         file.set_len(0).map_err(|e| CoreError::Io(e.to_string()))?;
         file.write_all(pid.to_string().as_bytes())
             .map_err(|e| CoreError::Io(e.to_string()))?;
 
-        Ok(InstanceLock { file })
+        Ok(InstanceLock {
+            file: Some(file),
+            #[cfg(windows)]
+            path: path.to_path_buf(),
+        })
     }
 
     pub fn new(root: PathBuf, stream_port: u16, control_port: u16) -> Self {


### PR DESCRIPTION
## Summary
This PR establishes the Windows build baseline for issue #26.

It does two things:
1. Adds a Windows GitLab CI build job (`wbeamd-server.exe`) targeting runner tags `windows,zerotier,build`.
2. Removes unconditional Unix-only compile paths from `wbeamd-core`, so `wbeamd-server` can compile for Windows targets.

## What changed
- CI:
  - Added `build_windows_server` in `.gitlab-ci.yml`.
  - Uses PowerShell `before_script` to compute `WBEAM_VERSION` and import MSVC env from `VsDevCmd.bat`.
  - Builds `wbeamd-server.exe` and publishes `dist/*windows*.exe` + `dist/VERSION.txt`.

- Rust core portability:
  - `wbeamd-core/Cargo.toml`: `nix` moved to `target.'cfg(unix)'.dependencies`.
  - `infra/mod.rs`: X11 modules now behind `#[cfg(unix)]`.
  - `infra/display_backends/mod.rs`: added non-unix Linux stub module + unix-only runtime handle variants.
  - `infra/host_probe.rs`: removed `nix::libc` dependency (`geteuid`) in favor of portable uid detection fallback.
  - `infra/process.rs`: process termination is now platform-aware (`kill` on unix, `taskkill` on Windows); streamer path supports `.exe` on Windows.
  - `lib.rs`: instance lock is now cross-platform (unix `flock`, windows lockfile + cleanup).

## Validation
- `cargo check -p wbeamd-server` ✅
- `cargo check -p wbeamd-server --target x86_64-pc-windows-gnu` ✅

## Scope notes
- This PR is intentionally scoped to `wbeamd-server` build portability baseline.
- `wbeamd-streamer` remains Linux-focused and is not built in the new Windows job.

Refs #26
