### PR TITLE
[e37-i40] Canonicalize runtime profile loading path

### DIFF
--- a/host/rust/crates/wbeamd-core/src/lib.rs
+++ b/host/rust/crates/wbeamd-core/src/lib.rs
@@ -347,79 +347,69 @@ fn runtime_config_path_for_session(root: &Path, session_label: Option<&str>) -> 
 }
 
 fn load_presets_from_training_files(root: &Path) -> Option<BTreeMap<String, ActiveConfig>> {
-    // New canonical path: config/training/profiles.json
-    // Legacy archived fallback: archive/legacy/proto/config/profiles.json
-    let candidates = [
-        root.join("config/training/profiles.json"),
-        root.join("archive/legacy/proto/config/profiles.json"),
-    ];
+    let path = root.join("config/training/profiles.json");
 
-    for path in candidates {
-        let raw = match std::fs::read_to_string(&path) {
-            Ok(v) => v,
-            Err(e) => {
-                debug!("presets: cannot read {}: {e}", path.display());
-                continue;
-            }
-        };
-        let value: serde_json::Value = match serde_json::from_str(&raw) {
-            Ok(v) => v,
-            Err(e) => {
-                warn!("presets: invalid JSON in {}: {e}", path.display());
-                continue;
-            }
-        };
-        let Some(profiles) = value.get("profiles").and_then(|v| v.as_object()) else {
-            warn!("presets: missing .profiles object in {}", path.display());
-            continue;
-        };
-
-        let mut out = BTreeMap::new();
-        for (name, node) in profiles {
-            let values = node.get("values").and_then(|v| v.as_object());
-            let size = values
-                .and_then(|v| v.get("PROTO_CAPTURE_SIZE"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("1280x720")
-                .to_string();
-            let fps = values
-                .and_then(|v| v.get("PROTO_CAPTURE_FPS"))
-                .and_then(|v| v.as_u64())
-                .unwrap_or(60) as u32;
-            let bitrate_kbps = values
-                .and_then(|v| v.get("PROTO_CAPTURE_BITRATE_KBPS"))
-                .and_then(|v| v.as_u64())
-                .unwrap_or(10_000) as u32;
-
-            out.insert(
-                name.clone(),
-                ActiveConfig {
-                    profile: name.clone(),
-                    encoder: "h264".to_string(),
-                    cursor_mode: "embedded".to_string(),
-                    size,
-                    fps,
-                    bitrate_kbps,
-                    debug_fps: 0,
-                    intra_only: false,
-                },
-            );
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!("presets: cannot read {}: {e}", path.display());
+            return None;
         }
-
-        if out.is_empty() {
-            warn!("presets: no profiles loaded from {}", path.display());
-            continue;
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("presets: invalid JSON in {}: {e}", path.display());
+            return None;
         }
-        info!(
-            "presets: loaded {} profile(s) from {}",
-            out.len(),
-            path.display()
+    };
+    let Some(profiles) = value.get("profiles").and_then(|v| v.as_object()) else {
+        warn!("presets: missing .profiles object in {}", path.display());
+        return None;
+    };
+
+    let mut out = BTreeMap::new();
+    for (name, node) in profiles {
+        let values = node.get("values").and_then(|v| v.as_object());
+        let size = values
+            .and_then(|v| v.get("PROTO_CAPTURE_SIZE"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("1280x720")
+            .to_string();
+        let fps = values
+            .and_then(|v| v.get("PROTO_CAPTURE_FPS"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(60) as u32;
+        let bitrate_kbps = values
+            .and_then(|v| v.get("PROTO_CAPTURE_BITRATE_KBPS"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(10_000) as u32;
+
+        out.insert(
+            name.clone(),
+            ActiveConfig {
+                profile: name.clone(),
+                encoder: "h264".to_string(),
+                cursor_mode: "embedded".to_string(),
+                size,
+                fps,
+                bitrate_kbps,
+                debug_fps: 0,
+                intra_only: false,
+            },
         );
-        return Some(out);
     }
 
-    warn!("presets: no training profiles found in config/training or archive/legacy/proto/config");
-    None
+    if out.is_empty() {
+        warn!("presets: no profiles loaded from {}", path.display());
+        return None;
+    }
+    info!(
+        "presets: loaded {} profile(s) from {}",
+        out.len(),
+        path.display()
+    );
+    Some(out)
 }
 
 fn default_config_from_presets(presets: &BTreeMap<String, ActiveConfig>) -> ActiveConfig {

--- a/host/training/wizard.py
+++ b/host/training/wizard.py
@@ -30,7 +30,7 @@ TRAINING_DIR = ROOT / "config" / "training"
 PROFILE_FILE = TRAINING_DIR / "profiles.json"
 PROFILE_OUTPUT_DIR = TRAINING_DIR / "profiles"
 DESKTOP_RUNTIME_FILE = (
-    ROOT / "src" / "apps" / "desktop-tauri" / "src" / "config" / "trained-profile-runtime.json"
+    ROOT / "desktop" / "apps" / "desktop-tauri" / "src" / "config" / "trained-profile-runtime.json"
 )
 LOG_DIR = ROOT / "logs"
 

--- a/workload.md
+++ b/workload.md
@@ -64,10 +64,10 @@ Child issues in execution order:
    - Status: completed (`docs/profile-config-canonical-contract-2026-03-12.md`)
 3. #40 Implement canonical loading and remove fallback drift
    - https://github.com/ppotepa/WBeam/issues/40
-   - Status: next
+   - Status: completed (core loader canonicalized + wizard export path fixed)
 4. #41 Align API profile surface with canonical model
    - https://github.com/ppotepa/WBeam/issues/41
-   - Status: todo
+   - Status: next
 5. #42 Final report and close Epic #37
    - https://github.com/ppotepa/WBeam/issues/42
    - Status: todo


### PR DESCRIPTION
Implements issue #40 for Epic #37.\n\nChanges:\n- remove archive/legacy fallback in core preset loader\n- keep canonical source: config/training/profiles.json\n- fix wizard desktop runtime export path to desktop/apps/desktop-tauri/...\n- update workload status (#40 completed, #41 next)\n\nValidation:\n- python3 -m py_compile host/training/wizard.py\n- scripts/ci/check-repo-layout.sh\n- scripts/ci/check-boundaries.sh\n- scripts/ci/validate-e2e-matrix.sh\n\nRef: #37, #40