### PR TITLE
[e48-i50] Align checks/docs with true-archive policy

### DIFF
--- a/docs/agents.workflow.md
+++ b/docs/agents.workflow.md
@@ -58,6 +58,8 @@ Never place in public release assets/notes:
 - Avoid force-push on protected branches (`master`, `release`) except emergency alignment.
 - Keep branch protection enabled.
 - Keep docs under `docs/` and update workflow docs together with process changes.
+- Treat `archive/legacy/*` as true archive: historical assets only, no implicit runtime dependency.
+- If compatibility tooling uses archive assets, it must be explicit opt-in and documented.
 
 ## 9) Repository Structure Source Of Truth
 

--- a/docs/repo-structure.md
+++ b/docs/repo-structure.md
@@ -1,6 +1,6 @@
 # Repository Structure Source Of Truth
 
-Last updated: 2026-03-11
+Last updated: 2026-03-12
 
 ## Goal
 
@@ -66,6 +66,12 @@ WBeam/
 2. Do not add new compatibility wrappers or alias trees.
 3. Keep wrappers (`./wbeam`, `./trainer.sh`, `./desktop.sh`) stable.
 4. Keep CI guard scripts green for structure and boundary checks.
+
+## Archive Policy
+
+- `archive/legacy/*` is historical-only (true archive), not default runtime source.
+- CI may verify archive presence as historical assets, but must not require archive executables for canonical runtime flow.
+- Any compatibility execution path touching archive content must be explicit opt-in and documented.
 
 ## Structure Validation
 

--- a/scripts/ci/validate-e2e-matrix.sh
+++ b/scripts/ci/validate-e2e-matrix.sh
@@ -36,12 +36,13 @@ require_exec "./trainer.sh"
 require_exec "./desktop.sh"
 require_exec "./host/scripts/run_wbeamd.sh"
 require_exec "./host/scripts/run_wbeamd_debug.sh"
-require_exec "./archive/legacy/proto_x11/run.sh"
 
 echo "[matrix] check canonical workflow files"
 require_file "./host/training/wizard.py"
 require_file "./desktop/apps/trainer-tauri/package.json"
 require_file "./desktop/apps/desktop-tauri/package.json"
+
+echo "[matrix] check historical archive markers"
 require_file "./archive/legacy/proto/README.md"
 require_file "./archive/legacy/proto_x11/README.md"
 


### PR DESCRIPTION
Implements #50.\n\nChanges:\n- CI matrix no longer requires archive executable in canonical runtime checks\n- repo/workflow docs aligned with true-archive policy\n\nRef: #48 #50