### PR TITLE
[e99-i99] fix false Arch header warning in evdi diagnose

### DIFF
--- a/scripts/evdi-diagnose.sh
+++ b/scripts/evdi-diagnose.sh
@@ -227,10 +227,16 @@ else
     fi
 fi
 
+RUNNING_KERNEL=$(uname -r)
+
 print_check "Linux headers installed (needed for DKMS build)"
 case "$PM" in
     pacman)
-        is_package_installed "linux-headers" "$PM" && pass "linux-headers" || warn "linux-headers not installed"
+        if [ -e "/lib/modules/$RUNNING_KERNEL/build/Makefile" ]; then
+            pass "/lib/modules/$RUNNING_KERNEL/build"
+        else
+            warn "headers for running kernel $RUNNING_KERNEL not installed"
+        fi
         ;;
     apt)
         if dpkg -l | grep -q "^ii.*linux-headers"; then
@@ -249,7 +255,6 @@ case "$PM" in
 esac
 
 print_check "Linux headers match running kernel"
-RUNNING_KERNEL=$(uname -r)
 if [ -e "/lib/modules/$RUNNING_KERNEL/build/Makefile" ]; then
     pass "/lib/modules/$RUNNING_KERNEL/build"
 else


### PR DESCRIPTION
Closes #99

## Summary
- avoid a false `linux-headers` warning on pacman-based systems that use a custom kernel headers package
- check the running kernel header path (`/lib/modules/$(uname -r)/build/Makefile`) instead of hardcoding the `linux-headers` package name
- keep the change scoped to `scripts/evdi-diagnose.sh` only

## Changes
| File | Change |
|------|--------|
| `scripts/evdi-diagnose.sh` | Use the active kernel build path as the pacman-side header signal and reuse the detected running kernel value |

## Validation
- [x] Reproduced the false warning on CachyOS before the change
- [x] Re-ran `bash scripts/evdi-diagnose.sh --verbose` after the change
- [x] Confirmed the false warning disappeared while the rest of the diagnostic remained healthy
- [x] Ran shellcheck on `scripts/evdi-diagnose.sh` (no blocking findings)

## Notes
This PR intentionally keeps the fix minimal and only addresses the false warning reported in issue #99. Other pacman-side scripts may deserve a follow-up audit, but they are out of scope for this change.